### PR TITLE
Allow automatic discovery of a main program's name

### DIFF
--- a/app/Bin32.hs
+++ b/app/Bin32.hs
@@ -17,8 +17,8 @@ import Truncate              (makeBin32)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (binary)
 
-header :: String
-header = "trbin32 - Truncate 32-bit floating-point numbers represented in binary"
+description :: String
+description = "Truncate 32-bit floating-point numbers represented in binary"
 
 main :: IO ()
-main = btMain binary makeBin32 header
+main = btMain binary makeBin32 description

--- a/app/Bin64.hs
+++ b/app/Bin64.hs
@@ -17,8 +17,8 @@ import Truncate              (makeBin64)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (binary)
 
-header :: String
-header = "trbin64 - Truncate 64-bit floating-point numbers represented in binary"
+description :: String
+description = "Truncate 64-bit floating-point numbers represented in binary"
 
 main :: IO ()
-main = btMain binary makeBin64 header
+main = btMain binary makeBin64 description

--- a/app/Dec32.hs
+++ b/app/Dec32.hs
@@ -17,8 +17,8 @@ import Truncate              (makeDec32)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (decimal)
 
-header :: String
-header = "trdec32 - Truncate 32-bit floating-point numbers represented in decimal"
+description :: String
+description = "Truncate 32-bit floating-point numbers represented in decimal"
 
 main :: IO ()
-main = btMain decimal makeDec32 header
+main = btMain decimal makeDec32 description

--- a/app/Dec64.hs
+++ b/app/Dec64.hs
@@ -17,8 +17,8 @@ import Truncate              (makeDec64)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (decimal)
 
-header :: String
-header = "trdec64 - truncate 64-bit floating-point numbers in decimal"
+description :: String
+description = "truncate 64-bit floating-point numbers in decimal"
 
 main :: IO ()
-main = btMain decimal makeDec64 header
+main = btMain decimal makeDec64 description

--- a/app/Hex32.hs
+++ b/app/Hex32.hs
@@ -17,8 +17,8 @@ import Truncate              (makeHex32)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (hexadecimal)
 
-header :: String
-header = "trhex32 - Truncate 32-bit floating-point numbers represented in hexadecimal"
+description :: String
+description = "Truncate 32-bit floating-point numbers represented in hexadecimal"
 
 main :: IO ()
-main = btMain hexadecimal makeHex32 header
+main = btMain hexadecimal makeHex32 description

--- a/app/Hex64.hs
+++ b/app/Hex64.hs
@@ -17,8 +17,8 @@ import Truncate              (makeHex64)
 import Truncate.Main         (btMain)
 import Truncate.Main.Readers (hexadecimal)
 
-header :: String
-header = "trhex64 - Truncate 64-bit floating-point numbers represented in hexadecimal"
+description :: String
+description = "Truncate 64-bit floating-point numbers represented in hexadecimal"
 
 main :: IO ()
-main = btMain hexadecimal makeHex64 header
+main = btMain hexadecimal makeHex64 description


### PR DESCRIPTION
Just use a description of the program as input, and get the name of the executable being run from the system. This is consistent with how the usage string is determined by optparse-applicative.