### PR TITLE
Use helper functions for converting to words

### DIFF
--- a/src/Truncate.hs
+++ b/src/Truncate.hs
@@ -43,14 +43,10 @@ module Truncate
 
 
 ------------------------------------------------------------------------
-import Data.Char           (digitToInt)
 import Data.Binary.IEEE754 ( wordToFloat
                            , floatToWord
                            , wordToDouble
                            , doubleToWord
-                           )
-import Numeric             ( readInt
-                           , readHex
                            )
 import Text.Read           (readMaybe)
 
@@ -95,8 +91,8 @@ data Binary = Bin32 String
             | Bin64 String
 
 instance Truncatable Binary where
-    makeBits (Bin32 b)   = WordF32 $ fst (head (readInt 2 (`elem` "01") digitToInt b))
-    makeBits (Bin64 b)   = WordF64 $ fst (head (readInt 2 (`elem` "01") digitToInt b))
+    makeBits (Bin32 b)   = WordF32 $ binToWord b
+    makeBits (Bin64 b)   = WordF64 $ binToWord b
     fromBits (WordF32 b) = Bin32 (wordToBin b)
     fromBits (WordF64 b) = Bin64 (wordToBin b)
 
@@ -171,8 +167,8 @@ data Hexadecimal = Hex32 String
                  | Hex64 String
 
 instance Truncatable Hexadecimal where
-    makeBits (Hex32 s)   = WordF32 $ fst (head (readHex s))
-    makeBits (Hex64 s)   = WordF64 $ fst (head (readHex s))
+    makeBits (Hex32 s)   = WordF32 $ hexToWord s
+    makeBits (Hex64 s)   = WordF64 $ hexToWord s
     fromBits (WordF32 b) = Hex32 (wordToHex b)
     fromBits (WordF64 b) = Hex64 (wordToHex b)
 

--- a/src/Truncate/Internal.hs
+++ b/src/Truncate/Internal.hs
@@ -29,15 +29,20 @@ module Truncate.Internal where
 ------------------------------------------------------------------------
 import Data.Bits
 import Data.Word
-import Data.Char (intToDigit)
-import Numeric   (showIntAtBase)
+import Data.Char ( digitToInt
+                 , intToDigit
+                 )
+import Numeric   ( readInt
+                 , readHex
+                 , showIntAtBase
+                 )
 
 
 ------------------------------------------------------------------------
 -- | A wrapper around 'Word32' and 'Word64' types
 data WordF = WordF32 Word32
-         | WordF64 Word64
-         deriving (Eq, Show)
+           | WordF64 Word64
+           deriving (Eq, Show)
 
 
 ------------------------------------------------------------------------
@@ -69,6 +74,9 @@ dropBits n = (flip shiftL) n . (flip shiftR) n
 -----------------------------------------------------------------------
 -- Functions for handling binary representations
 
+binToWord :: Num a => String -> a
+binToWord b = fst $ head $ readInt 2 (`elem` "01") digitToInt b
+
 wordToBin :: (Show a, Integral a) => a -> String
 wordToBin b = showIntAtBase 2 intToDigit b ""
 
@@ -77,6 +85,9 @@ validBin = all (`elem` "01")
 
 -----------------------------------------------------------------------
 -- Functions for handling hexadecimal representations
+
+hexToWord :: (Num a, Eq a) => String -> a
+hexToWord s = fst (head (readHex s))
 
 wordToHex :: (Show a, Integral a) => a -> String
 wordToHex b = showIntAtBase 16 intToDigit b ""


### PR DESCRIPTION
Use the same function for converting 32-/64-bit binary strings to words of appropriate length, and likewise for hexadecimal strings.