### PR TITLE
Remove -Werror from compile flags

### DIFF
--- a/fp-truncate.cabal
+++ b/fp-truncate.cabal
@@ -28,12 +28,12 @@ library
                        , data-binary-ieee754
                        , optparse-applicative
     default-language:    Haskell2010
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds
+    ghc-options:         -Wall -fno-warn-unused-binds
 
 executable tr32b
     hs-source-dirs:      app
     main-is:             Bin32.hs
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     build-depends:       base
                        , fp-truncate
     default-language:    Haskell2010
@@ -49,7 +49,7 @@ executable tr64b
 executable tr32d
     hs-source-dirs:      app
     main-is:             Dec32.hs
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     build-depends:       base
                        , fp-truncate
     default-language:    Haskell2010
@@ -57,7 +57,7 @@ executable tr32d
 executable tr64d
     hs-source-dirs:      app
     main-is:             Dec64.hs
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     build-depends:       base
                        , fp-truncate
     default-language:    Haskell2010
@@ -65,7 +65,7 @@ executable tr64d
 executable tr32h
     hs-source-dirs:      app
     main-is:             Hex32.hs
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     build-depends:       base
                        , fp-truncate
     default-language:    Haskell2010
@@ -73,7 +73,7 @@ executable tr32h
 executable tr64h
     hs-source-dirs:      app
     main-is:             Hex64.hs
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     build-depends:       base
                        , fp-truncate
     default-language:    Haskell2010
@@ -100,7 +100,7 @@ test-suite fp-truncate-test
                        , HUnit
                        , data-binary-ieee754
                        , fp-truncate
-    ghc-options:         -Wall -Werror -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:         -Wall -fno-warn-unused-binds -threaded -rtsopts -with-rtsopts=-N
     default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
Using `-Werror` for building may cause build errors if a version of GHC with different warning sets than those tested is used. Keeping the warnings turned on but no-longer causing an error if a warning is triggered allows developers to see what they need to fix, but prevents end users from seeing build failures.